### PR TITLE
Fix comment wording in open sculling portal

### DIFF
--- a/open-sculling/index.md
+++ b/open-sculling/index.md
@@ -26,7 +26,7 @@ search_exclude: true
     </div>
   </div>
 
-  <div id="open-sculling-content" class="coach-content" style="display: none;"> <!-- Re-used class for structure, can be renamed -->
+  <div id="open-sculling-content" class="coach-content" style="display: none;"> <!-- Reused class for structure, can be renamed -->
     <h1>Open Sculling Resources</h1>
 
     <div class="info-box tip">


### PR DESCRIPTION
## Summary
- fix wording in an HTML comment in `open-sculling/index.md`

## Testing
- `bundle exec jekyll build` *(fails: No repo name found)*

------
https://chatgpt.com/codex/tasks/task_b_685eb3c79f4c832b89802077da43d9fc