### PR TITLE
Fix nav links for Contact and FAQ

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,9 +55,9 @@ navigation:
       - title: Club Policies
         url: /about/club-policies/
       - title: Contact
-        url: /about/contact/
+        url: /about/contact.html
       - title: FAQ
-        url: /about/faq/
+        url: /about/faq.html
 
 # Site info
 organization: "Ann Arbor Rowing Club"


### PR DESCRIPTION
## Summary
- fix the navigation URLs for Contact and FAQ pages

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685eb3af1470832bb7d6dbd2f7ac0eda