### PR TITLE
Add skip link, focus styles and accessible nav

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -30,7 +30,7 @@ Addressing the items below will bring the site substantially closer to WCAG 2.
   *Acceptance*: Colour contrast ≥ 4.5 : 1 for normal text as verified with the W3C contrast tool.
   *Why*: Satisfies **SC 1.4.3 Contrast (Minimum)**.([w3.org][2])
 
-* [ ] **Insert a keyboard “Skip to main content” link**
+* [x] **Insert a keyboard “Skip to main content” link**
   *Location*: immediately after `<body>` in `_layouts/default.html`.
   *Action*:
 
@@ -41,7 +41,7 @@ Addressing the items below will bring the site substantially closer to WCAG 2.
   *Acceptance*: Pressing `Tab` once from the top focuses the link and sends focus to `#main`.
   *Why*: Required by **SC 2.4.1 Bypass Blocks**.([w3.org][3])
 
-* [ ] **Ensure always‑visible focus styling**
+* [x] **Ensure always‑visible focus styling**
   *Location*: `_sass/custom.scss`.
   *Action*:
 
@@ -56,7 +56,7 @@ Addressing the items below will bring the site substantially closer to WCAG 2.
 
 ## Navigation & layout
 
-* [ ] **Make the dropdown navigation keyboard‑friendly**
+* [x] **Make the dropdown navigation keyboard‑friendly**
   *Location*: `_includes/header.html` or equivalent.
   *Action* (quick method): wrap each submenu in native `<details>`/`<summary>` so it opens with **Enter/Space** and closes with **Esc**.
 
@@ -70,7 +70,7 @@ Addressing the items below will bring the site substantially closer to WCAG 2.
   *Acceptance*: All items reachable via **Tab/Shift‑Tab**; visible focus ring; submenu collapses when focus leaves.
   *Why*: Ensures fly‑out menus remain operable without a mouse.([w3.org][5])
 
-* [ ] **Add main landmarks**
+* [x] **Add main landmarks**
   *Location*: wrap each page’s primary content in `<main id="main">`.
   *Acceptance*: Browser accessibility tree shows exactly one `<main>` per page.
   *Why*: Improves semantic structure per HTML accessibility guidance.([developer.mozilla.org][6])

--- a/_layouts/coach.html
+++ b/_layouts/coach.html
@@ -15,6 +15,7 @@
 </head>
 
 <body>
+    <a class="sr-only sr-only-focusable" href="#main">Skip to main content</a>
     <div class="page-header">
         <div class="container-lg px-3 my-5">
             <h1 class="project-name">{{ site.title | default: site.github.repository_name }}</h1>
@@ -31,23 +32,28 @@
         <nav class="site-nav">
             <ul class="fallback-nav">
                 {% for item in site.navigation %}
-                <li
-                    class="nav-item {% if item.subitems %}has-dropdown{% endif %} {% if page.url contains item.url and item.url != '/' %}active{% elsif page.url == '/' and item.url == '/' %}active{% endif %}">
-                    <a href="{{ site.baseurl }}{{ item.url }}">{{ item.title }}</a>
-                    {% if item.subitems %}
-                    <ul class="dropdown-menu">
-                        {% for subitem in item.subitems %}
-                        <li {% if page.url contains subitem.url %}class="active" {% endif %}><a
-                                href="{{ site.baseurl }}{{ subitem.url }}">{{ subitem.title }}</a></li>
-                        {% endfor %}
-                    </ul>
-                    {% endif %}
+                {% if item.subitems %}
+                <li class="nav-item has-dropdown">
+                    <details>
+                        <summary>{{ item.title }}</summary>
+                        <ul class="dropdown-menu">
+                            {% for subitem in item.subitems %}
+                            <li {% if page.url contains subitem.url %}class="active" {% endif %}><a
+                                    href="{{ site.baseurl }}{{ subitem.url }}">{{ subitem.title }}</a></li>
+                            {% endfor %}
+                        </ul>
+                    </details>
                 </li>
+                {% else %}
+                <li class="nav-item {% if page.url contains item.url and item.url != '/' %}active{% elsif page.url == '/' and item.url == '/' %}active{% endif %}">
+                    <a href="{{ site.baseurl }}{{ item.url }}">{{ item.title }}</a>
+                </li>
+                {% endif %}
                 {% endfor %}
             </ul>
         </nav>
 
-        <main class="main-content">
+        <main id="main" class="main-content">
             <div class="coach-portal-banner">
                 <div class="banner-icon"><i class="fas fa-lock"></i></div>
                 <div class="banner-text">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,7 @@
 </head>
 
 <body>
+  <a class="sr-only sr-only-focusable" href="#main">Skip to main content</a>
   <div class="page-header">
     <div class="container-lg px-3 my-5">
       <h1 class="project-name">{{ site.title | default: site.github.repository_name }}</h1>
@@ -31,21 +32,27 @@
     <nav class="site-nav">
       <ul class="fallback-nav">
         {% for item in site.navigation %}
-        <li class="nav-item {% if item.subitems %}has-dropdown{% endif %}">
-          <a href="{{ site.baseurl }}{{ item.url }}">{{ item.title }}</a>
-          {% if item.subitems %}
-          <ul class="dropdown-menu">
-            {% for subitem in item.subitems %}
-            <li><a href="{{ site.baseurl }}{{ subitem.url }}">{{ subitem.title }}</a></li>
-            {% endfor %}
-          </ul>
-          {% endif %}
+        {% if item.subitems %}
+        <li class="nav-item has-dropdown">
+          <details>
+            <summary>{{ item.title }}</summary>
+            <ul class="dropdown-menu">
+              {% for subitem in item.subitems %}
+              <li><a href="{{ site.baseurl }}{{ subitem.url }}">{{ subitem.title }}</a></li>
+              {% endfor %}
+            </ul>
+          </details>
         </li>
+        {% else %}
+        <li class="nav-item">
+          <a href="{{ site.baseurl }}{{ item.url }}">{{ item.title }}</a>
+        </li>
+        {% endif %}
         {% endfor %}
       </ul>
     </nav>
 
-    <main class="main-content">
+    <main id="main" class="main-content">
       {{ content }}
     </main>
 

--- a/_layouts/open-sculling.html
+++ b/_layouts/open-sculling.html
@@ -15,6 +15,7 @@
 </head>
 
 <body>
+    <a class="sr-only sr-only-focusable" href="#main">Skip to main content</a>
     <div class="page-header">
         <div class="container-lg px-3 my-5">
             <h1 class="project-name">{{ site.title | default: site.github.repository_name }}</h1>
@@ -31,23 +32,28 @@
         <nav class="site-nav">
             <ul class="fallback-nav">
                 {% for item in site.navigation %}
-                <li
-                    class="nav-item {% if item.subitems %}has-dropdown{% endif %} {% if page.url contains item.url and item.url != '/' %}active{% elsif page.url == '/' and item.url == '/' %}active{% endif %}">
-                    <a href="{{ site.baseurl }}{{ item.url }}">{{ item.title }}</a>
-                    {% if item.subitems %}
-                    <ul class="dropdown-menu">
-                        {% for subitem in item.subitems %}
-                        <li {% if page.url contains subitem.url %}class="active" {% endif %}><a
-                                href="{{ site.baseurl }}{{ subitem.url }}">{{ subitem.title }}</a></li>
-                        {% endfor %}
-                    </ul>
-                    {% endif %}
+                {% if item.subitems %}
+                <li class="nav-item has-dropdown">
+                    <details>
+                        <summary>{{ item.title }}</summary>
+                        <ul class="dropdown-menu">
+                            {% for subitem in item.subitems %}
+                            <li {% if page.url contains subitem.url %}class="active" {% endif %}><a
+                                    href="{{ site.baseurl }}{{ subitem.url }}">{{ subitem.title }}</a></li>
+                            {% endfor %}
+                        </ul>
+                    </details>
                 </li>
+                {% else %}
+                <li class="nav-item {% if page.url contains item.url and item.url != '/' %}active{% elsif page.url == '/' and item.url == '/' %}active{% endif %}">
+                    <a href="{{ site.baseurl }}{{ item.url }}">{{ item.title }}</a>
+                </li>
+                {% endif %}
                 {% endfor %}
             </ul>
         </nav>
 
-        <main class="main-content">
+        <main id="main" class="main-content">
             <div class="coach-portal-banner open-sculling-banner"> <!-- Changed class for styling if needed -->
                 <div class="banner-icon"><i class="fas fa-lock"></i></div>
                 <div class="banner-text">

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -229,3 +229,33 @@
 // before: #7c7c7c on #ffffff ≈ 2.8:1 (fails)
 $footer-text-color: #595959; // ≥ 4.5:1
 footer { color: $footer-text-color; }
+
+// Accessible skip link helpers
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.sr-only-focusable:focus,
+.sr-only-focusable:active {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+}
+
+// Ensure focus indicators are always visible
+:focus-visible {
+  outline: 3px solid #005fcc;
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- add skip link link and main IDs in layouts
- update navigation to use `<details>` for keyboard access
- include global focus-visible rule and sr-only helper classes
- check off completed tasks in TASKS.md

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_68618ed9aa38832b9a040c2e20620937